### PR TITLE
Fix publishLint gradle error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Fix Found more than one jar in the 'lintPublish' configuration.
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Correction to fix gradle error :

```
Execution failed for task ':app:prepareLintJar'.
Found more than one jar in the 'lintChecks' configuration. Only one file is supported. If using a separate Gradle project, make sure compilation dependencies are using compileOnly
```